### PR TITLE
expose a method for counting used connections

### DIFF
--- a/capped.go
+++ b/capped.go
@@ -1,6 +1,6 @@
 package mgopool
 
-import "gopkg.in/mgo.v2"
+import mgo "gopkg.in/mgo.v2"
 
 type capped struct {
 	pool   Pool
@@ -34,6 +34,10 @@ func (p *capped) Put(s *mgo.Session) {
 func (p *capped) Close() {
 	close(p.leases)
 	p.pool.Close()
+}
+
+func (p *capped) Used() int {
+	return p.pool.Used()
 }
 
 var _ Pool = &capped{}

--- a/capped_test.go
+++ b/capped_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/mgo.v2"
+	mgo "gopkg.in/mgo.v2"
 )
 
 func TestCapped_Get(t *testing.T) {
@@ -91,4 +91,19 @@ func TestCapped_Close(t *testing.T) {
 	assert.NotPanics(t, func() {
 		orig.Copy().Close()
 	})
+}
+
+func TestCapped_Used(t *testing.T) {
+	orig := session(t)
+	defer orig.Close()
+
+	p := NewCapped(orig, 1)
+	defer p.Close()
+	assert.Equal(t, 0, p.Used())
+
+	leak := p.Get()
+	assert.Equal(t, 1, p.Used())
+
+	p.Put(leak)
+	assert.Equal(t, 0, p.Used())
 }

--- a/interface.go
+++ b/interface.go
@@ -10,7 +10,7 @@
 // Both a leaky and capped version of the Pool is available, depending on need.
 package mgopool
 
-import "gopkg.in/mgo.v2"
+import mgo "gopkg.in/mgo.v2"
 
 // The Pool interface describes the mechanisms for retrieving and releasing mgo.Sessions. The pool should be used in
 // place of calling Copy/Clone and Close on mgo.Session directly.
@@ -23,6 +23,10 @@ type Pool interface {
 	// Put releases an *mgo.Session back into the Pool. Only healthy sessions (or nil) should be returned to the pool. If
 	// a session is errors, Refresh should be called before releasing it to the Pool.
 	Put(*mgo.Session)
+
+	// Used is the total number of outstanding leases associated with this Pool.
+	// Note, this is just a snapshot of the used leased at the time this method was invoked
+	Used() int
 
 	// Close drains the Pool, closing all held sessions. The initial session is not closed by this method. Calling Get or
 	// Put on a closed pool will result in a panic.

--- a/leaky_test.go
+++ b/leaky_test.go
@@ -66,3 +66,19 @@ func TestLeak_Close(t *testing.T) {
 		orig.Copy().Close()
 	})
 }
+
+func TestLeaky_Used(t *testing.T) {
+	orig := session(t)
+	defer orig.Close()
+
+	p := NewLeaky(orig, 1)
+	defer p.Close()
+	assert.Equal(t, 0, p.Used())
+
+	leak := p.Get()
+	assert.Equal(t, 1, p.Used())
+
+	p.Put(p.Get())
+	p.Put(leak)
+	assert.Equal(t, 0, p.Used())
+}

--- a/script/test
+++ b/script/test
@@ -5,6 +5,6 @@ set -e
 
 test -z "$(gofmt -l -w .       | tee /dev/stderr)"
 test -z "$(golint ./...        | tee /dev/stderr)"
-test -z "$(go tool vet -test . | tee /dev/stderr)"
+test -z "$(go tool vet -tests . | tee /dev/stderr)"
 
 go test -v -race -cover ./...


### PR DESCRIPTION
Adds a new method to the base `Pool` interface for fetching the number of sessions used. This information is useful for statting / logging and exposing it as a first class datapoint is something that a lot of pooled connection libraries do ([e.g.](https://golang.org/pkg/database/sql/#DBStats))