### PR TITLE
Use globalsign maintained mgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Package mgopool provides buffer implementations around [mgo.Session (v2)][mgo].
 
 ```
-go get gopkg.in/mgo.v2
+go get github.com/globalsign/mgo
 go get github.com/vsco/mgopool
 ```
 
@@ -69,10 +69,10 @@ func doSomething(s *mgo.Session) error {
 }
 ```
 
-[mgo]:           https://godoc.org/gopkg.in/mgo.v2
-[Session.Copy]:  https://godoc.org/gopkg.in/mgo.v2#Session.Copy
-[Session.Clone]: https://godoc.org/gopkg.in/mgo.v2#Session.Clone
-[Session.Close]: https://godoc.org/gopkg.in/mgo.v2#Session.Close
+[mgo]:           https://godoc.org/github.com/globalsign/mgo
+[Session.Copy]:  https://godoc.org/github.com/globalsign/mgo#Session.Copy
+[Session.Clone]: https://godoc.org/github.com/globalsign/mgo#Session.Clone
+[Session.Close]: https://godoc.org/github.com/globalsign/mgo#Session.Close
 
 ## Testing
 

--- a/capped.go
+++ b/capped.go
@@ -1,6 +1,6 @@
 package mgopool
 
-import mgo "gopkg.in/mgo.v2"
+import mgo "github.com/globalsign/mgo"
 
 type capped struct {
 	pool   Pool

--- a/capped_test.go
+++ b/capped_test.go
@@ -5,8 +5,8 @@ import (
 
 	"time"
 
+	mgo "github.com/globalsign/mgo"
 	"github.com/stretchr/testify/assert"
-	mgo "gopkg.in/mgo.v2"
 )
 
 func TestCapped_Get(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 
 	"fmt"
 
-	"gopkg.in/mgo.v2"
+	"github.com/globalsign/mgo"
 )
 
 func Example() {

--- a/interface.go
+++ b/interface.go
@@ -10,7 +10,7 @@
 // Both a leaky and capped version of the Pool is available, depending on need.
 package mgopool
 
-import mgo "gopkg.in/mgo.v2"
+import mgo "github.com/globalsign/mgo"
 
 // The Pool interface describes the mechanisms for retrieving and releasing mgo.Sessions. The pool should be used in
 // place of calling Copy/Clone and Close on mgo.Session directly.

--- a/interface_test.go
+++ b/interface_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"gopkg.in/mgo.v2"
+	"github.com/globalsign/mgo"
 )
 
 func session(t *testing.T) *mgo.Session {

--- a/leaky.go
+++ b/leaky.go
@@ -3,7 +3,7 @@ package mgopool
 import (
 	"sync/atomic"
 
-	mgo "gopkg.in/mgo.v2"
+	mgo "github.com/globalsign/mgo"
 )
 
 type leaky struct {


### PR DESCRIPTION
As raised here: https://github.com/vsco/mgopool/issues/6, we should update `mgopool` to use the `globalsign` namespace for clients that have dropped support for the unmaintained `mgo.V2` version.